### PR TITLE
Mention players in Telegram split message

### DIFF
--- a/amplify/backend/function/TeamSplitterAPI/src/service/telegram_webhook_handler.mjs
+++ b/amplify/backend/function/TeamSplitterAPI/src/service/telegram_webhook_handler.mjs
@@ -124,7 +124,8 @@ export const createTeamSplitMessage = (teams) => {
     message += `*Team ${team.name}*\n`;
     
     for(let player of team.players) {
-      message += `${player.firstName ? player.firstName : ''} ${player.lastName ? player.lastName : ''}\n`;
+      const name = `${player.firstName ? player.firstName : ''} ${player.lastName ? player.lastName : ''}`.trim();
+      message += player.id ? `[${name}](tg://user?id=${player.id})\n` : `${name}\n`;
     }
     
     message += '\n';


### PR DESCRIPTION
## Summary
- Replace plain name display with Telegram inline mentions (`[Name](tg://user?id=...)`) in split messages
- Falls back to plain name for players without a stored Telegram user ID

## Test plan
- [ ] Trigger a team split and verify players appear as tappable mentions in the Telegram message
- [ ] Confirm players without an ID still display their name correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)