### PR TITLE
Feat/sort splits desc

### DIFF
--- a/amplify/backend/function/TeamSplitterAPI/src/index.mjs
+++ b/amplify/backend/function/TeamSplitterAPI/src/index.mjs
@@ -1,4 +1,4 @@
-import {deletePoll, getPoll, getAllPollsPaginated, addVoteToPoll, removeVoteFromPoll, savePoll} from './repo/poll_repo.mjs';
+import {deletePoll, getPoll, getAllPollsPaginated, addVoteToPoll, removeVoteFromPoll, savePoll, updatePlayerInPollVotes} from './repo/poll_repo.mjs';
 import {getPlayer, deletePlayer, getAllPlayers, savePlayer} from './repo/player_repo.mjs';
 import {deleteGameSplit, getGameSplit, getGameSplitsByPoll, getAllGameSplitsPaginated, removePlayerFromSplit, saveGameSplit, movePlayerBetweenTeams} from './repo/game_split_repo.mjs';
 import {deleteGameSchedule, getGameSchedule, getAllGameSchedules, saveGameSchedule} from './repo/game_schedule_repo.mjs';
@@ -124,6 +124,7 @@ export const handler = async (event, context) => {
         exisinting.score = requestJSON.score;
         
         await savePlayer(exisinting);
+        await updatePlayerInPollVotes(playerId, { firstName: exisinting.firstName, lastName: exisinting.lastName, score: exisinting.score });
         body = exisinting;
         break;
       }

--- a/amplify/backend/function/TeamSplitterAPI/src/index.mjs
+++ b/amplify/backend/function/TeamSplitterAPI/src/index.mjs
@@ -124,7 +124,8 @@ export const handler = async (event, context) => {
         exisinting.score = requestJSON.score;
         
         await savePlayer(exisinting);
-        await updatePlayerInPollVotes(playerId, { firstName: exisinting.firstName, lastName: exisinting.lastName, score: exisinting.score });
+        const completedPollIds = ((await getAllGameSplits()).Items || []).map(s => s.pollId);
+        await updatePlayerInPollVotes(playerId, { firstName: exisinting.firstName, lastName: exisinting.lastName, score: exisinting.score }, completedPollIds);
         body = exisinting;
         break;
       }

--- a/amplify/backend/function/TeamSplitterAPI/src/repo/poll_repo.mjs
+++ b/amplify/backend/function/TeamSplitterAPI/src/repo/poll_repo.mjs
@@ -123,9 +123,10 @@ export const removeVoteFromPollByPlayer = async (pollId, playerId) => {
   );
 }
 
-export const updatePlayerInPollVotes = async (playerId, playerData) => {
+export const updatePlayerInPollVotes = async (playerId, playerData, excludePollIds = []) => {
   const polls = (await dynamo.send(new ScanCommand({ TableName: tableName }))).Items || [];
-  const pollsWithPlayer = polls.filter(p => p.answers?.some(a => a.player?.id === playerId));
+  const excludeSet = new Set(excludePollIds);
+  const pollsWithPlayer = polls.filter(p => !excludeSet.has(p.id) && p.answers?.some(a => a.player?.id === playerId));
 
   await Promise.all(pollsWithPlayer.map(poll => {
     const updatedAnswers = poll.answers.map(a =>

--- a/amplify/backend/function/TeamSplitterAPI/src/repo/poll_repo.mjs
+++ b/amplify/backend/function/TeamSplitterAPI/src/repo/poll_repo.mjs
@@ -123,6 +123,23 @@ export const removeVoteFromPollByPlayer = async (pollId, playerId) => {
   );
 }
 
+export const updatePlayerInPollVotes = async (playerId, playerData) => {
+  const polls = (await dynamo.send(new ScanCommand({ TableName: tableName }))).Items || [];
+  const pollsWithPlayer = polls.filter(p => p.answers?.some(a => a.player?.id === playerId));
+
+  await Promise.all(pollsWithPlayer.map(poll => {
+    const updatedAnswers = poll.answers.map(a =>
+      a.player?.id === playerId ? { ...a, player: { ...a.player, ...playerData } } : a
+    );
+    return dynamo.send(new UpdateCommand({
+      TableName: tableName,
+      Key: { id: poll.id },
+      UpdateExpression: 'SET answers = :answers',
+      ExpressionAttributeValues: { ':answers': updatedAnswers }
+    }));
+  }));
+}
+
 export const savePoll = async (pollDocument) => {
   return await dynamo.send(
     new PutCommand({

--- a/src/pages/poll/PollGamesPage.tsx
+++ b/src/pages/poll/PollGamesPage.tsx
@@ -20,7 +20,7 @@ export const PollGamesPage = ({ pollId, refreshKey }: GamesPageProps) => {
     useEffect(() => {
         getGameSplitsByPollId(pollId)
             .then((data) => {
-                setGameSplits(data.content);
+                setGameSplits([...data.content].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()));
                 setError(null);
             })
             .catch((err) => {

--- a/src/pages/poll/PollVotesPage.tsx
+++ b/src/pages/poll/PollVotesPage.tsx
@@ -119,7 +119,10 @@ export const PollVotesPage = ({ pollId, poll, onVoteChange }: Props) => {
                     <AddPlayer
                         mode="edit"
                         player={editPlayer}
-                        cancelButtonHandler={() => setEditPlayer(null)}
+                        cancelButtonHandler={() => {
+                                setEditPlayer(null);
+                                getVotesForPoll(pollId).then(setVotes);
+                            }}
                     />
                 )}
             </Dialog>

--- a/src/pages/poll/PollVotesPage.tsx
+++ b/src/pages/poll/PollVotesPage.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, Button, FormControl, IconButton, InputLabel, MenuItem, Select, SelectChangeEvent, TextField, Tooltip } from "@mui/material"
+import { Autocomplete, Button, Dialog, FormControl, IconButton, TextField, Tooltip } from "@mui/material"
 import { useEffect, useState } from "react"
 import { Player } from "api/Player.types"
 import { Poll, PollVote } from "api/Poll.types"
@@ -6,6 +6,7 @@ import { getPlayers } from "services/PlayerService"
 import { addPollVote, getVotesForPoll, deletePollVote } from "services/PollService"
 import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmDialog from 'components/ConfirmDialog';
+import AddPlayer from "pages/players/AddPlayer";
 
 type Props = {
     poll: Poll
@@ -22,6 +23,7 @@ export const PollVotesPage = ({ pollId, poll, onVoteChange }: Props) => {
     const [selectedPlayer, setSelectedPlayer] = useState<Player | null> (null);
     const [addPlayerEnabled, setAddPlayerButtonEnabled] = useState(false);
     const [selectedVote, setSelectedVote] = useState<PollVote>({} as PollVote);
+    const [editPlayer, setEditPlayer] = useState<Player | null>(null);
 
     const handleAddPlayer = async (e: any) => {
         e.preventDefault();
@@ -85,7 +87,11 @@ export const PollVotesPage = ({ pollId, poll, onVoteChange }: Props) => {
             <ol>
                 {votes.map((vote) => {
                     return (
-                        <li key={vote.id}>{vote.player ? `${vote.player.firstName || ''} ${vote.player.lastName || ''}`: `deleted user`}
+                        <li key={vote.id}>
+                            {vote.player
+                                ? <span style={{ cursor: "pointer", textDecoration: "underline dotted" }} onClick={() => setEditPlayer(vote.player)}>{vote.player.firstName || ''} {vote.player.lastName || ''}</span>
+                                : `deleted user`
+                            }
                             <Tooltip title="Delete">
                                 <IconButton onClick={(e) => { 
                                     setOpen(true); 
@@ -108,6 +114,15 @@ export const PollVotesPage = ({ pollId, poll, onVoteChange }: Props) => {
                     </ConfirmDialog>
             </ol>
 
+            <Dialog open={!!editPlayer} onClose={() => setEditPlayer(null)}>
+                {editPlayer && (
+                    <AddPlayer
+                        mode="edit"
+                        player={editPlayer}
+                        cancelButtonHandler={() => setEditPlayer(null)}
+                    />
+                )}
+            </Dialog>
         </div>
     )
 }

--- a/src/pages/teams/TeamCard.tsx
+++ b/src/pages/teams/TeamCard.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { Team, GameSplit } from "../../api/Team.types";
-import { IconButton, Tooltip } from "@mui/material";
+import { Dialog, IconButton, Tooltip } from "@mui/material";
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Player } from "api/Player.types";
 import ConfirmDialog from 'components/ConfirmDialog';
 import { deleteGameSplitPlayerEntry } from "services/GameSplitService";
+import AddPlayer from "pages/players/AddPlayer";
 
 type TeamCardProps = {
     team: Team
@@ -15,12 +16,14 @@ type TeamCardProps = {
     onTouchDrop?: (x: number, y: number) => void
     isTouchDragTarget?: boolean
     draggingPlayer?: Player | null
+    onPlayerUpdated?: () => void
 }
 
-const TeamCard = ({team, gameSplit, onDragStart, onDrop, onTouchMove, onTouchDrop, isTouchDragTarget, draggingPlayer}: TeamCardProps) => {
+const TeamCard = ({team, gameSplit, onDragStart, onDrop, onTouchMove, onTouchDrop, isTouchDragTarget, draggingPlayer, onPlayerUpdated}: TeamCardProps) => {
     const [open, setOpen] = useState(false);
     const [selectedPlayer, setSelectedPlayer] = useState<Player>({} as Player);
     const [isMouseDragOver, setIsMouseDragOver] = useState(false);
+    const [editPlayer, setEditPlayer] = useState<Player | null>(null);
 
     const onDeletePlayerEntry = async (gameId: string, player: Player) => {
         await deleteGameSplitPlayerEntry(gameId, player.id);
@@ -84,7 +87,12 @@ const TeamCard = ({team, gameSplit, onDragStart, onDrop, onTouchMove, onTouchDro
                                 onTouchDrop?.(touch.clientX, touch.clientY);
                             }}
                         >
-                            {player.firstName} {player.lastName} {player.score}
+                            <span
+                                style={{ cursor: "pointer", textDecoration: "underline dotted", userSelect: "text" }}
+                                onClick={() => setEditPlayer(player)}
+                            >
+                                {player.firstName} {player.lastName} {player.score}
+                            </span>
                             {gameSplit &&
                                 <Tooltip title="Delete">
                                     <IconButton onClick={() => {
@@ -111,6 +119,18 @@ const TeamCard = ({team, gameSplit, onDragStart, onDrop, onTouchMove, onTouchDro
                     Are you sure you want to delete this player?
                 </ConfirmDialog>
             }
+            <Dialog open={!!editPlayer} onClose={() => setEditPlayer(null)}>
+                {editPlayer && (
+                    <AddPlayer
+                        mode="edit"
+                        player={editPlayer}
+                        cancelButtonHandler={() => {
+                            setEditPlayer(null);
+                            onPlayerUpdated?.();
+                        }}
+                    />
+                )}
+            </Dialog>
         </div>
     );
 }

--- a/src/pages/teams/TeamCardList.tsx
+++ b/src/pages/teams/TeamCardList.tsx
@@ -8,6 +8,7 @@ type TeamCardListProps = {
     teams: Team[]
     gameSplit?: GameSplit
     draggable?: boolean
+    onPlayerUpdated?: () => void
 }
 
 export type DragState = {
@@ -15,7 +16,7 @@ export type DragState = {
     fromTeamName: string
 }
 
-export const TeamCardList = ({teams: initialTeams, gameSplit, draggable = true}: TeamCardListProps) => {
+export const TeamCardList = ({teams: initialTeams, gameSplit, draggable = true, onPlayerUpdated}: TeamCardListProps) => {
     const [teams, setTeams] = useState<Team[]>(initialTeams);
     useEffect(() => { 
         setTeams(initialTeams);
@@ -89,6 +90,7 @@ export const TeamCardList = ({teams: initialTeams, gameSplit, draggable = true}:
                     key={team.name}
                     team={team}
                     gameSplit={gameSplit}
+                    onPlayerUpdated={onPlayerUpdated}
                     {...(draggable && {
                         onDragStart,
                         onDrop: applyDrop,

--- a/src/pages/teams/TeamSplitPage.tsx
+++ b/src/pages/teams/TeamSplitPage.tsx
@@ -17,6 +17,7 @@ const TeamSplitPage = ({ pollId, refreshKey, onSplitSuccess }: TeamSplitPageProp
     const [error, setError] = useState(null);
     const [teamsNum, setTeamsNum] = useState(2);
     const [splitStrategy, setSplitStrategy] = useState("TEAM_SCORE_BALANCE");
+    const [playerUpdateKey, setPlayerUpdateKey] = useState(0);
 
     useEffect(() => {
         getPollTeamSplit(pollId, teamsNum, splitStrategy)
@@ -30,7 +31,7 @@ const TeamSplitPage = ({ pollId, refreshKey, onSplitSuccess }: TeamSplitPageProp
                 setTeams(null)
             })
             .finally(() => setLoading(false))
-    }, [pollId, teamsNum, splitStrategy, refreshKey])
+    }, [pollId, teamsNum, splitStrategy, refreshKey, playerUpdateKey])
 
     const handleSplit = () => {
         setSplitting(true);
@@ -99,7 +100,7 @@ const TeamSplitPage = ({ pollId, refreshKey, onSplitSuccess }: TeamSplitPageProp
                     alignItems: 'center',
                     justifyContent: 'center'
                 }}>
-                    <TeamCardList teams={teams} draggable={false} />
+                    <TeamCardList teams={teams} draggable={false} onPlayerUpdated={() => setPlayerUpdateKey(k => k + 1)} />
                 </Box>
             }
         </div>


### PR DESCRIPTION
Here's a summary of all changes in this branch:

Sort splits descending — Game splits on the poll page are now sorted most recent first (by createdAt desc).

Edit player rating from team split — Player names in the Team Split section are clickable (dotted underline). Clicking opens the edit player modal. After saving, the team split re-fetches automatically to reflect the updated score/name.

Edit player from Players Going list — Player names in the Players Going list are also clickable with the same edit modal. After saving, the votes list re-fetches to reflect name/score changes.

Text selectability fix — Player names in the team split cards were unselectable due to userSelect: none on the drag list item. The player name span now overrides this with userSelect: text.

Resplit on vote add/remove — Adding or removing a player vote now automatically re-fetches the team split preview so the split stays in sync with who's going.