### PR TITLE
YP6M-2980 Restore repo backend after amplify pull so CI deploys Lambd…

### DIFF
--- a/.github/workflows/amplify-publish-dev.yaml
+++ b/.github/workflows/amplify-publish-dev.yaml
@@ -31,8 +31,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Amplify Pull 
+      - name: Amplify Pull
         run: amplify pull --appId ${{ vars.AMPLIFY_APP_ID }} --envName dev --yes
+
+      # amplify pull overwrites the local Lambda source with the deployed version,
+      # discarding committed backend changes. Restore the repo's backend so they deploy.
+      - name: Restore repo backend
+        run: git checkout -- amplify/backend
 
       - name: Amplify status
         run: amplify status

--- a/.github/workflows/amplify-publish-prd.yaml
+++ b/.github/workflows/amplify-publish-prd.yaml
@@ -31,8 +31,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Amplify Pull 
+      - name: Amplify Pull
         run: amplify pull --appId ${{ vars.AMPLIFY_APP_ID }} --envName prd --yes
+
+      # amplify pull overwrites the local Lambda source with the deployed version,
+      # discarding committed backend changes. Restore the repo's backend so they deploy.
+      - name: Restore repo backend
+        run: git checkout -- amplify/backend
 
       - name: Amplify status
         run: amplify status


### PR DESCRIPTION
…a changes

amplify pull overwrites the local Lambda source with the deployed version, so committed backend/function changes were dropped before amplify status/publish ran and never deployed. Re-apply the repo's tracked amplify/backend after pull in both dev and prd workflows.